### PR TITLE
Add custom setter for Media objects

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 // Spotify Playback Speed || 2022 Github-@rnikko
 (() => {
+  const extensionName = 'spotify-playback-speed-extension'; 
   const base = document.createElement;
   let spotifyPlaybackEl;
 
@@ -63,7 +64,14 @@
     localStorage.setItem('sps-pp', pp);
     localStorage.setItem('sps-speed-min', min);
     localStorage.setItem('sps-speed-max', max);
+
+    spotifyPlaybackEl.playbackRate = {
+        source: extensionName,
+        value: val,
+    };
+    spotifyPlaybackEl.preservesPitch = pp;
   };
+
   let showSettings = false;
   let showMain = false;
   const toggleShowSettings = () => {
@@ -76,6 +84,7 @@
       spsSettings.style.display = 'none';
     }
   };
+
   const toggleShowMain = () => {
     showMain = !showMain;
     if (showMain) {
@@ -92,6 +101,7 @@
     minInput.value = 0.5;
     maxInput.value = 2;
   };
+
   const saveMinMax = () => {
     sliderInput.min = minInput.value;
     sliderInput.max = maxInput.value;
@@ -169,6 +179,7 @@
     style.textContent = '#sps{user-select:none;border-width:0 !important;border-style:solid !important;border-color:#e5e7eb}.sps-common{display:flex;flex-wrap:nowrap;align-items:center;height:32px}.sps-header{color:#f0f0f0;font-weight:600;line-height:1}#sps-main{border:1px solid #282828;border-right:0;bottom:88px;right:0;position:absolute}#sps-icon{display:flex;flex-wrap:wrap;justify-content:center;width:2rem;height:2rem}#sps-controls{padding:.5rem .75rem;background-color:#171717;width:320px}#sps-settings{width:240px;padding:.5rem .75rem;background-color:#171717}#sps-settings input{margin-left:.5rem;width:56px;border-radius:.125rem;padding-left:.125rem;padding-right:.125rem;text-align:center;font-size:.875rem}.sps-text-button:hover{background-color:#9B9B9B;cursor:pointer}#sps button:hover{cursor:pointer}#sps button,#sps input{border-width:0 !important;border-style:solid !important;border-color:#e5e7eb}#sps button:disabled{cursor:not-allowed}#sps input[type=number]::-webkit-outer-spin-button,#sps input[type=number]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}#sps input[type=number]:focus{outline:0}#sps input[type=range]{-webkit-appearance:none;width:100%;height:6px;background:#494949;border-radius:.375rem;background-image:linear-gradient(#fff,#fff);background-size:70% 100%;background-repeat:no-repeat}#sps input[type=range]:hover{background-image:linear-gradient(#2edb64,#2edb64)}#sps input[type=range]::-webkit-slider-thumb{-webkit-appearance:none}#sps input[type=range]::-webkit-slider-runnable-track{width:calc(100% + 16px);height:6px;padding:8px 0;background:transparent}#sps input[type=range]:hover::-webkit-slider-runnable-track{cursor:ew-resize}#sps input[type=range]:hover::-webkit-slider-thumb{display:block;cursor:ew-resize}#sps input[type=range]::-webkit-slider-thumb{display:none;-webkit-appearance:none;border-radius:50%;height:14px;width:14px;background:white;box-shadow:0 4px 6px -1px rgb(0 0 0 / .1),0 2px 4px -2px rgb(0 0 0 / .1);margin-top:-7px}.sps-icon-active,.sps-icon-active:hover{color:#2edb64}.sps-hover-white:hover{color:#FFF}.sps-text-button{background-color:#535353;color:white;font-weight:600;font-size:.625rem;padding:.125rem .25rem;border-radius:.125rem}';
     document.head.append(style);
   };
+
   const addJS = () => {
     // set vars
     ppCheckbox = document.querySelector('input[name="sps-pp"]');
@@ -270,14 +281,26 @@
       setValues();
     };
 
-    // set values
+    // Allow only {source: this_extension, value: number} type of objects to
+    // be set in playbackRate
+    if (spotifyPlaybackEl instanceof HTMLMediaElement) {
+      const playbackRateDescriptor = Object.getOwnPropertyDescriptor(
+          HTMLMediaElement.prototype, "playbackRate"
+      );
+      Object.defineProperty(HTMLMediaElement.prototype, "playbackRate", {
+        set: function (value) {
+          const errMsg = 'Only ' + extensionName + ' can change playback speed';
+          if (value.source !== extensionName) {
+            console.error(errMsg);
+            return playbackRateDescriptor.set.call(this, Number(sliderInput.value));
+          }
+
+          return playbackRateDescriptor.set.call(this, value.value);
+        },
+      });
+    }
+
     setValues();
-    setInterval(() => {
-      if (spotifyPlaybackEl) {
-        spotifyPlaybackEl.playbackRate = Number(sliderInput.value);
-        spotifyPlaybackEl.preservesPitch = ppCheckbox.checked;
-      }
-    }, 4);
   };
 
   let tries = 0;
@@ -292,7 +315,8 @@
       addHTML();
       addJS();
       console.log('sps✅');
-    } catch {
+    } catch (error) {
+      console.log(extensionName, error);
       if (tries <= 20) {
         setTimeout(init, 500);
         return;


### PR DESCRIPTION
## Add custom setter for Media objects to prevent spotify to change playback rate.

I think that this fix effects all Media objects. Wanted to make it only for `spotifyPlaybackEl` but failed. But it works and it seems not be a problem.
After this fix playbackRate can be modified only with `{ source: extensionName,  value: val };` type of objects 